### PR TITLE
Fix date formatter bug and add tests

### DIFF
--- a/src/utils/__tests__/dateUtils.test.ts
+++ b/src/utils/__tests__/dateUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { formatPublishedDate } from '../dateUtils';
+
+describe('formatPublishedDate', () => {
+  it('formats dates less than 24 hours as hours ago', () => {
+    const now = new Date();
+    const twelveHoursAgo = new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString();
+    expect(formatPublishedDate(twelveHoursAgo)).toBe('12 hours ago');
+  });
+
+  it('formats dates less than 7 days as days ago', () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatPublishedDate(twoDaysAgo)).toBe('2 days ago');
+  });
+
+  it('formats dates less than 30 days as weeks ago', () => {
+    const now = new Date();
+    const fifteenDaysAgo = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatPublishedDate(fifteenDaysAgo)).toBe('2 weeks ago');
+  });
+
+  it('formats older dates with locale string', () => {
+    const now = new Date();
+    const oldDate = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    const expected = new Date(oldDate).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+    expect(formatPublishedDate(oldDate)).toBe(expected);
+  });
+});

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,29 +1,31 @@
 export const formatPublishedDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffTime = Math.abs(now.getTime() - date.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    
-    // If less than 24 hours ago
-    if (diffDays === 1) {
-      const hours = Math.ceil(diffTime / (1000 * 60 * 60));
-      return `${hours} hours ago`;
-    }
-    // If less than 7 days ago
-    if (diffDays < 7) {
-      return `${diffDays} days ago`;
-    }
-    // If less than 1 month ago
-    if (diffDays < 30) {
-      const weeks = Math.floor(diffDays / 7);
-      return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
-    }
-  
-    // For older videos, show the actual date
-    return date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric'
-    });
-  };
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffTime = Math.abs(now.getTime() - date.getTime());
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  // If less than 24 hours ago
+  if (diffTime < 1000 * 60 * 60 * 24) {
+    const hours = Math.ceil(diffTime / (1000 * 60 * 60));
+    return `${hours} hours ago`;
+  }
+
+  // If less than 7 days ago
+  if (diffDays < 7) {
+    return `${diffDays} days ago`;
+  }
+
+  // If less than 1 month ago
+  if (diffDays < 30) {
+    const weeks = Math.floor(diffDays / 7);
+    return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
+  }
+
+  // For older videos, show the actual date
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+};
   


### PR DESCRIPTION
## Summary
- fix `formatPublishedDate` to handle dates under a day correctly
- add unit tests for the date formatter

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457217dc9c8333a72e3d5806e7c4cf